### PR TITLE
Adjust some definitions of harassment

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,18 +108,18 @@ This Code of Conduct is released under [CC-BY-4.0](https://creativecommons.org/l
 * Offensive comments related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, race, age, regional discrimination, political or religious affiliation
 * Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment
 * Deliberate misgendering. This includes deadnaming or persistently using a pronoun that does not correctly reflect a person’s gender identity. You must address people by the name they give you when not addressing them by their username or handle
-* Physical contact and simulated physical contact (eg, textual descriptions like "hug" or "backrub") without consent or after a request to stop
+* Inappropriate physical contact and simulated physical contact (eg, textual descriptions like "hug" or "backrub") without consent or after a request to stop
 * Threats of violence, both physical and psychological
 * Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm
 * Deliberate intimidation
 * Stalking or following
-* Harassing photography or recording, including logging online activity for harassment purposes
+* Harassing photography or recording, including accessing private online activity for harassment purposes
 * Sustained disruption of discussion
 * Unwelcome sexual attention, including gratuitous or off-topic sexual images or behaviour
 * Pattern of inappropriate social contact, such as requesting/assuming inappropriate levels of intimacy with others
 * Continued one-on-one communication after requests to cease
 * Deliberate "outing" of any aspect of a person’s identity without their consent except as necessary to protect others from intentional abuse
-* Publication of non-harassing private communication
+* Publication of private communication without second party consent
 
 ## Appendix B: Examples of Moderation
 


### PR DESCRIPTION
Makes slight modifications to some of the definitions of harassment.

Specifically:
- Explicity prohibits _inappropriate_ physical or simulated physical
  contact (_high-five_! is not harassment)
- "Logging online activity" is vague and likely not valid harassment,
  especially if the "activity" is publically visible "Accessing private
  online activity" is far more precise and constitutes actual wrong doing.
- Disallow publication of ANY private communication without consent,
  regardless of "harassing" nature.  This is to prevent potentially
  slanderous statements if one party believes behavior was harassing and
  the other does not.  Even if behavior is percieved as harassing, it
  should not then be fair game to publically publish, but should instead
  be brough privately to the moderators.
